### PR TITLE
Fix for idiotic bug in vector.c:reset_handler().

### DIFF
--- a/lib/lpc43xx/vector.c
+++ b/lib/lpc43xx/vector.c
@@ -192,7 +192,7 @@ void reset_handler(void)
 		*dest++ = *src++;
 	}
 
-	for (dest = &_bss; dest < &_ebss; dest++)
+	for (dest = &_bss; dest < &_ebss; )
 		*dest++ = 0;
 
 	/* Call the application's entry point. */


### PR DESCRIPTION
The zero initialization of the BSS was skipping every other word. So if your HackRF seems somewhat capricious, maybe this is why. I almost certainly introduced this bug back in September or so.
