### PR TITLE
Silence some warnings about unused function parameters

### DIFF
--- a/lib/sam/common/usart.c
+++ b/lib/sam/common/usart.c
@@ -58,10 +58,12 @@ void usart_set_flow_control(uint32_t usart, enum usart_flowcontrol fc)
 
 void usart_enable(uint32_t usart)
 {
+	(void) usart;
 }
 
 void usart_disable(uint32_t usart)
 {
+	(void) usart;
 }
 
 void usart_send(uint32_t usart, uint16_t data)

--- a/lib/stm32/common/spi_common_all.c
+++ b/lib/stm32/common/spi_common_all.c
@@ -101,6 +101,8 @@ void spi_reset(uint32_t spi_peripheral)
 		break;
 #endif
 	}
+#else
+	(void) spi_peripheral;
 #endif
 }
 


### PR DESCRIPTION
Fixes the following warnings:
```
../common/spi_common_all.c: In function 'spi_reset':
../common/spi_common_all.c:82:25: warning: unused parameter 'spi_peripheral' [-Wunused-parameter]
   82 | void spi_reset(uint32_t spi_peripheral)
      |                ~~~~~~~~~^~~~~~~~~~~~~~
../common/usart.c: In function 'usart_enable':
../common/usart.c:59:28: warning: unused parameter 'usart' [-Wunused-parameter]
   59 | void usart_enable(uint32_t usart)
      |                   ~~~~~~~~~^~~~~
../common/usart.c: In function 'usart_disable':
../common/usart.c:63:29: warning: unused parameter 'usart' [-Wunused-parameter]
   63 | void usart_disable(uint32_t usart)
      |                    ~~~~~~~~~^~~~~
```