### PR TITLE
Remove warning when building `sync.c` for Cortex-M0

### DIFF
--- a/lib/cm3/sync.c
+++ b/lib/cm3/sync.c
@@ -26,9 +26,7 @@ void __dmb()
 }
 
 /* Those are defined only on CM3 or CM4 */
-#if defined(__ARM_ARCH_6M__)
-#warning "sync not supported on ARMv6-M arch"
-#else
+#if defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
 
 uint32_t __ldrex(volatile uint32_t *addr)
 {


### PR DESCRIPTION
This warning doesn't serve any useful purpose:

```
../../cm3/sync.c:30:2: warning: #warning "sync not supported on ARMv6-M arch" [-Wcpp]
   30 | #warning "sync not supported on ARMv6-M arch"
      |  ^~~~~~~
```

This change gets rid of that warning, which has been similarly removed in upstream libopencm3.